### PR TITLE
Correct exception handling for failed item and familiar lookups

### DIFF
--- a/libkol/Familiar.py
+++ b/libkol/Familiar.py
@@ -18,15 +18,15 @@ class FamiliarMeta(ModelMeta):
         future = loop.create_future()
 
         async def getitem():
+            result = None
             try:
                 if isinstance(key, int):
                     result = await self.get(id=key)
                 else:
                     result = await self.get(name=key)
+                future.set_result(result)
             except DoesNotExist:
-                raise FamiliarNotFoundError(f"Cannot find a familiar with the token `{key}`")
-
-            future.set_result(result)
+                future.set_exception(FamiliarNotFoundError(f"Cannot find a familiar with the token `{key}`"))
 
         asyncio.ensure_future(getitem())
         return future

--- a/libkol/Item.py
+++ b/libkol/Item.py
@@ -35,6 +35,7 @@ class ItemMeta(ModelMeta):
         future = loop.create_future()
 
         async def getitem():
+            result = None
             try:
                 if isinstance(key, int):
                     # Most desc_ids are 9 digits but there are 14 that aren't.
@@ -45,11 +46,10 @@ class ItemMeta(ModelMeta):
                         result = await self.get_or_discover(id=key)
                 else:
                     result = await self.get(name=key)
+                future.set_result(result)
+                
             except DoesNotExist:
-                raise ItemNotFoundError(f"Cannot find an item with the token `{key}`")
-
-
-            future.set_result(result)
+                future.set_exception(ItemNotFoundError(f"Cannot find an item with the token `{key}`"))
 
         asyncio.ensure_future(getitem())
         return future


### PR DESCRIPTION
Sets exceptions on futures rather than raising directly. On the way past, set result so it doesn't chuck "referenced before assignment" warnings.